### PR TITLE
Permissioned programs

### DIFF
--- a/examples/barebones/src/lib.rs
+++ b/examples/barebones/src/lib.rs
@@ -41,6 +41,7 @@ mod tests {
     fn test_should_sign() {
         let signature_request = InitialState {
             data: "some_data_longer_than_10_bytes".to_string().into_bytes(),
+            signature_request_key: [0; 32].to_vec(),
         };
 
         assert!(BarebonesProgram::evaluate(signature_request).is_ok());
@@ -51,6 +52,7 @@ mod tests {
         // data being checked is under 10 bytes in length
         let signature_request = InitialState {
             data: "under10".to_string().into_bytes(),
+            signature_request_key: [0; 32].to_vec(),
         };
 
         assert!(BarebonesProgram::evaluate(signature_request).is_err());

--- a/examples/basic-transaction/src/lib.rs
+++ b/examples/basic-transaction/src/lib.rs
@@ -55,6 +55,7 @@ mod tests {
         let signature_request = InitialState {
             // `data` is an RLP serialized ETH transaction with the recipient set to `0x772b9a9e8aa1c9db861c6611a82d251db4fac990`
             data: "0xef01808094772b9a9e8aa1c9db861c6611a82d251db4fac990019243726561746564204f6e20456e74726f7079018080".to_string().into_bytes(),
+            signature_request_key: [0; 32].to_vec(),
         };
 
         assert!(BasicTransaction::evaluate(signature_request).is_ok());
@@ -65,6 +66,7 @@ mod tests {
         let signature_request = InitialState {
             // `data` is the same as previous test, but recipient address ends in `1` instead of `0`, so it should fail
             data: "0xef01808094772b9a9e8aa1c9db861c6611a82d251db4fac991019243726561746564204f6e20456e74726f7079018080".to_string().into_bytes(),
+            signature_request_key: [0; 32].to_vec(),
         };
 
         assert!(BasicTransaction::evaluate(signature_request).is_err());

--- a/examples/permissioned/Cargo.toml
+++ b/examples/permissioned/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "template-permissioned"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+ec-core ={ workspace = true }
+
+# These are used by `cargo component`
+[package.metadata.component]
+package = "entropy:template-permissioned"
+
+[package.metadata.component.target]
+path = "../../wit"
+
+[package.metadata.component.dependencies]

--- a/examples/permissioned/src/lib.rs
+++ b/examples/permissioned/src/lib.rs
@@ -1,0 +1,57 @@
+//! This example shows having an allow list defining who is able to submit signature requests
+#![no_std]
+
+extern crate alloc;
+
+use alloc::string::ToString;
+
+use ec_core::{bindgen::Error, bindgen::*, export_program, prelude::*};
+
+// TODO confirm this isn't an issue for audit
+register_custom_getrandom!(always_fail);
+
+pub struct PermissionedProgram;
+
+/// The list of substrate account IDs of users who may use this program
+const ALLOWED_AUTHORS: [[u8; 32]; 2] = [[1; 32], [2; 32]];
+
+impl Program for PermissionedProgram {
+    fn evaluate(signature_request: InitialState) -> Result<(), Error> {
+        let signature_request_key: [u8; 32] = signature_request
+            .signature_request_key
+            .try_into()
+            .map_err(|_| Error::Evaluation("Singature request key must be 32 bytes".to_string()))?;
+        if ALLOWED_AUTHORS.contains(&signature_request_key) {
+            Ok(())
+        } else {
+            Err(Error::Evaluation("Author not in allow list".to_string()))
+        }
+    }
+}
+
+export_program!(PermissionedProgram);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_sign() {
+        let signature_request = InitialState {
+            data: b"some_data".to_vec(),
+            signature_request_key: [1; 32].to_vec(),
+        };
+
+        assert!(PermissionedProgram::evaluate(signature_request).is_ok());
+    }
+
+    #[test]
+    fn test_should_error() {
+        let signature_request = InitialState {
+            data: b"some_data".to_vec(),
+            signature_request_key: [0; 32].to_vec(),
+        };
+
+        assert!(PermissionedProgram::evaluate(signature_request).is_err());
+    }
+}

--- a/runtime/tests/runtime.rs
+++ b/runtime/tests/runtime.rs
@@ -12,6 +12,7 @@ fn test_barebones_component() {
     let longer_than_10 = "asdfasdfasdfasdf".to_string();
     let initial_state = InitialState {
         data: longer_than_10.into_bytes(),
+        signature_request_key: [0; 32].to_vec(),
     };
 
     let res = runtime.evaluate(BAREBONES_COMPONENT_WASM, &initial_state);
@@ -26,6 +27,7 @@ fn test_barebones_component_fails_with_data_length_less_than_10() {
     let shorter_than_10 = "asdf".to_string();
     let initial_state = InitialState {
         data: shorter_than_10.into_bytes(),
+        signature_request_key: [0; 32].to_vec(),
     };
 
     let res = runtime.evaluate(BAREBONES_COMPONENT_WASM, &initial_state);

--- a/wit/application.wit
+++ b/wit/application.wit
@@ -11,6 +11,8 @@ world program {
 
   record initial-state {
     /// The preimage of the user's data under program evaulation (eg. RLP-encoded ETH transaction request).
-    data: list<u8>
+    data: list<u8>,
+    /// The substrate account Id of the caller
+    signature-request-key: list<u8>
   }
 }


### PR DESCRIPTION
This example is maybe more controversial than the others as it makes changes to `InitialState` and the wit file.

But the idea is that we should always pass the `signature request id` (the substrate ID of whoever is requesting to sign the message) to programs as well as the message we want to sign.

This allows for 'permissioned' mode where we have different rules for different users (eg: Alice can send funds to anyone but bob can only send funds to a list of allowed addresses).

I am gonna make a corresponding PR to `entropy-core` which passes the author's sig request id at the point of evaluating a program.

The problem i have though, is i don't know how to put an array in a wit file.  I can only put `list` which becomes `Vec`.  I want something which translates to a `[u8; 32]`.