### PR TITLE
Add signing context to aux data

### DIFF
--- a/examples/device-key-proxy/src/lib.rs
+++ b/examples/device-key-proxy/src/lib.rs
@@ -53,12 +53,14 @@ pub struct AuxData {
     pub public_key: String,
     /// base64-encoded signature
     pub signature: String,
+    /// The context for the signature
+    pub context: String,
 }
 
 trait DeviceKey {
     type PublicKey;
     type Signature;
-    fn verify_signature(&self, message: &[u8]) -> Result<(), Error>;
+    fn verify_signature(&self, message: &[u8], context: &[u8]) -> Result<(), Error>;
     fn from_base64(public_key: &[u8], signature: &[u8]) -> Result<Self, Error>
     where
         Self: Sized;
@@ -83,7 +85,7 @@ impl DeviceKey for Ecdsa {
     type PublicKey = EcdsaPublicKey;
     type Signature = EcdsaSignature;
 
-    fn verify_signature(&self, message: &[u8]) -> Result<(), Error> {
+    fn verify_signature(&self, message: &[u8], _context: &[u8]) -> Result<(), Error> {
         self.pub_key.verify(message, &self.signature).map_err(|_| {
             Error::InvalidSignatureRequest("Unable to verify ecdsa signature".to_string())
         })
@@ -134,7 +136,7 @@ impl DeviceKey for Ed25519 {
     type PublicKey = Ed25519PublicKey;
     type Signature = Ed25519Signature;
 
-    fn verify_signature(&self, message: &[u8]) -> Result<(), Error> {
+    fn verify_signature(&self, message: &[u8], _context: &[u8]) -> Result<(), Error> {
         self.pub_key.verify(message, &self.signature).map_err(|_| {
             Error::InvalidSignatureRequest("Unable to verify ed25519 signature".to_string())
         })
@@ -190,8 +192,8 @@ impl DeviceKey for Sr25519 {
     type PublicKey = Sr25519PublicKey;
     type Signature = Sr25519Signature;
 
-    fn verify_signature(&self, message: &[u8]) -> Result<(), Error> {
-        let context = signing_context(b"");
+    fn verify_signature(&self, message: &[u8], context: &[u8]) -> Result<(), Error> {
+        let context = signing_context(context);
         self.pub_key
             .verify(context.bytes(message), &self.signature)
             .map_err(|_| {
@@ -277,7 +279,8 @@ impl Program for DeviceKeyProxy {
                     aux_data_json.signature.as_bytes(),
                 )?;
                 verification_parameters.confirm_in_config(&config)?;
-                verification_parameters.verify_signature(signature_request.message.as_slice())?;
+                verification_parameters
+                    .verify_signature(signature_request.message.as_slice(), b"")?;
             }
             "sr25519" => {
                 let verification_parameters = Sr25519::from_base64(
@@ -285,7 +288,10 @@ impl Program for DeviceKeyProxy {
                     aux_data_json.signature.as_bytes(),
                 )?;
                 verification_parameters.confirm_in_config(&config)?;
-                verification_parameters.verify_signature(signature_request.message.as_slice())?;
+                verification_parameters.verify_signature(
+                    signature_request.message.as_slice(),
+                    aux_data_json.context.as_bytes(),
+                )?;
             }
             "ed25519" => {
                 let verification_parameters = Ed25519::from_base64(
@@ -293,7 +299,8 @@ impl Program for DeviceKeyProxy {
                     aux_data_json.signature.as_bytes(),
                 )?;
                 verification_parameters.confirm_in_config(&config)?;
-                verification_parameters.verify_signature(signature_request.message.as_slice())?;
+                verification_parameters
+                    .verify_signature(signature_request.message.as_slice(), b"")?;
             }
             _ => {
                 return Err(Error::InvalidSignatureRequest(

--- a/examples/device-key-proxy/src/tests.rs
+++ b/examples/device-key-proxy/src/tests.rs
@@ -49,6 +49,7 @@ fn test_ok_for_only_device_key_signatures() {
                 .as_bytes(),
         ),
         signature: BASE64_STANDARD.encode(ecdsa_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     let mut request_from_device_key = SignatureRequest {
         message: message.to_string().into_bytes(),
@@ -75,6 +76,7 @@ fn test_ok_for_only_device_key_signatures() {
         public_key_type: "sr25519".to_string(),
         public_key: BASE64_STANDARD.encode(device_keys.sr25519_keys[0].public),
         signature: BASE64_STANDARD.encode(sr25519_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     request_from_device_key.auxilary_data = Some(
         serde_json::to_string(&device_key_aux_data_json_sr25519.clone())
@@ -92,6 +94,7 @@ fn test_ok_for_only_device_key_signatures() {
         public_key_type: "ed25519".to_string(),
         public_key: BASE64_STANDARD.encode(device_keys.ed25519_keys[0].verifying_key()),
         signature: BASE64_STANDARD.encode(ed25519_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     request_from_device_key.auxilary_data = Some(
         serde_json::to_string(&device_key_aux_data_json_ed25519)
@@ -142,6 +145,7 @@ fn test_fail_bad_signatures() {
                 .as_bytes(),
         ),
         signature: BASE64_STANDARD.encode(ecdsa_non_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     let mut request_from_device_key = SignatureRequest {
         message: message.to_string().into_bytes(),
@@ -167,6 +171,7 @@ fn test_fail_bad_signatures() {
         public_key_type: "sr25519".to_string(),
         public_key: BASE64_STANDARD.encode(device_keys.sr25519_keys[0].public),
         signature: BASE64_STANDARD.encode(sr25519_non_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     request_from_device_key.auxilary_data = Some(
         serde_json::to_string(&device_key_aux_data_json_sr25519.clone())
@@ -186,6 +191,7 @@ fn test_fail_bad_signatures() {
         public_key_type: "ed25519".to_string(),
         public_key: BASE64_STANDARD.encode(device_keys.ed25519_keys[0].verifying_key()),
         signature: BASE64_STANDARD.encode(ed25519_non_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     request_from_device_key.auxilary_data = Some(
         serde_json::to_string(&device_key_aux_data_json_ed25519)
@@ -239,6 +245,7 @@ fn test_fails_pub_key_not_found() {
                 .as_bytes(),
         ),
         signature: BASE64_STANDARD.encode(ecdsa_non_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     let mut request_from_non_device_key = SignatureRequest {
         message: message.to_string().into_bytes(),
@@ -267,6 +274,7 @@ fn test_fails_pub_key_not_found() {
         public_key_type: "sr25519".to_string(),
         public_key: BASE64_STANDARD.encode(non_device_keys.sr25519_keys[0].public),
         signature: BASE64_STANDARD.encode(sr25519_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     request_from_non_device_key.auxilary_data = Some(
         serde_json::to_string(&non_device_key_aux_data_json_sr25519.clone())
@@ -290,6 +298,7 @@ fn test_fails_pub_key_not_found() {
         public_key_type: "ed25519".to_string(),
         public_key: BASE64_STANDARD.encode(non_device_keys.ed25519_keys[0].verifying_key()),
         signature: BASE64_STANDARD.encode(ed25519_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     request_from_non_device_key.auxilary_data = Some(
         serde_json::to_string(&device_key_aux_data_json_ed25519)
@@ -358,6 +367,7 @@ fn test_fails_with_no_aux_or_config() {
                 .as_bytes(),
         ),
         signature: BASE64_STANDARD.encode(ecdsa_device_key_signature.to_bytes()),
+        context: "".to_string(),
     };
     let mut request_from_device_key = SignatureRequest {
         message: message.to_string().into_bytes(),


### PR DESCRIPTION
Closes #65 added the context to the aux data, as this makes more sense to me, it should be passed with the message and signature not pre locked in on chain