### PR TITLE
Add oracle data to programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This will compile your program and put the `.wasm` binary file in `./binary-dir`
 Before running the runtime tests, you need to build the `template-barebones`, `infinite-loop` and `example-custom-hash` components. To do this, execute:
 
 ```bash
-cargo component build --release -p template-barebones -p infinite-loop -p example-custom-hash --target wasm32-unknown-unknown`
+cargo component build --release -p template-barebones -p infinite-loop -p example-custom-hash --target wasm32-unknown-unknown
 ```
 
 This will create the components in `target/wasm32-unknown-unknown/release/`.

--- a/examples/barebones-with-auxilary/src/lib.rs
+++ b/examples/barebones-with-auxilary/src/lib.rs
@@ -16,7 +16,11 @@ pub struct BarebonesWithAuxilary;
 impl Program for BarebonesWithAuxilary {
     /// This is the only function required by the program runtime. `signature_request` includes the message to be
     /// signed, eg. RLP-serialized Ethereum transaction request, raw x86_64 executable, etc.
-    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), Error> {
+    fn evaluate(
+        signature_request: SignatureRequest,
+        _config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
+    ) -> Result<(), Error> {
         let SignatureRequest {
             message,
             auxilary_data,
@@ -57,7 +61,7 @@ mod tests {
             auxilary_data: Some(vec![0x00]),
         };
 
-        assert!(BarebonesWithAuxilary::evaluate(signature_request, None).is_ok());
+        assert!(BarebonesWithAuxilary::evaluate(signature_request, None, None).is_ok());
     }
 
     /// Note, the program is written s.t. if `message` is less than 10 bytes, the program will error.
@@ -69,7 +73,7 @@ mod tests {
             auxilary_data: Some(vec![0x00]),
         };
 
-        assert!(BarebonesWithAuxilary::evaluate(signature_request, None).is_err());
+        assert!(BarebonesWithAuxilary::evaluate(signature_request, None, None).is_err());
     }
 
     /// Note, the program is written s.t. if `auxilary_data` is `None`, the program will error.
@@ -81,6 +85,6 @@ mod tests {
             auxilary_data: None,
         };
 
-        assert!(BarebonesWithAuxilary::evaluate(signature_request, None).is_err());
+        assert!(BarebonesWithAuxilary::evaluate(signature_request, None, None).is_err());
     }
 }

--- a/examples/barebones/src/lib.rs
+++ b/examples/barebones/src/lib.rs
@@ -16,7 +16,11 @@ pub struct BarebonesProgram;
 impl Program for BarebonesProgram {
     /// This is the only function required by the program runtime. `message` is the preimage of the curve element to be
     /// signed, eg. RLP-serialized Ethereum transaction request, raw x86_64 executable, etc.
-    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), Error> {
+    fn evaluate(
+        signature_request: SignatureRequest,
+        _config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
+    ) -> Result<(), Error> {
         let message: Vec<u8> = signature_request.message;
 
         // our program just checks that the length of the message is greater than 10
@@ -49,7 +53,7 @@ mod tests {
             auxilary_data: None,
         };
 
-        assert!(BarebonesProgram::evaluate(signature_request, None).is_ok());
+        assert!(BarebonesProgram::evaluate(signature_request, None, None).is_ok());
     }
 
     #[test]
@@ -60,6 +64,6 @@ mod tests {
             auxilary_data: None,
         };
 
-        assert!(BarebonesProgram::evaluate(signature_request, None).is_err());
+        assert!(BarebonesProgram::evaluate(signature_request, None, None).is_err());
     }
 }

--- a/examples/custom-hash/src/lib.rs
+++ b/examples/custom-hash/src/lib.rs
@@ -16,7 +16,11 @@ register_custom_getrandom!(always_fail);
 pub struct CustomHashExample;
 
 impl Program for CustomHashExample {
-    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), Error> {
+    fn evaluate(
+        signature_request: SignatureRequest,
+        _config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
+    ) -> Result<(), Error> {
         if signature_request.message.len() < 1 {
             return Err(Error::Evaluation(
                 "You need to give me SOME data to sign!".to_string(),

--- a/examples/device-key-proxy/src/lib.rs
+++ b/examples/device-key-proxy/src/lib.rs
@@ -250,6 +250,7 @@ impl Program for DeviceKeyProxy {
     fn evaluate(
         signature_request: SignatureRequest,
         raw_config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
     ) -> Result<(), Error> {
         let config_json = serde_json::from_slice::<UserConfig>(
             raw_config

--- a/examples/device-key-proxy/src/tests.rs
+++ b/examples/device-key-proxy/src/tests.rs
@@ -62,10 +62,12 @@ fn test_ok_for_only_device_key_signatures() {
 
     let config_bytes = serde_json::to_vec(&json_config).unwrap();
     // positive for edcsa
-    assert!(
-        DeviceKeyProxy::evaluate(request_from_device_key.clone(), Some(config_bytes.clone()))
-            .is_ok()
-    );
+    assert!(DeviceKeyProxy::evaluate(
+        request_from_device_key.clone(),
+        Some(config_bytes.clone()),
+        None
+    )
+    .is_ok());
     // positive for sr25519
     let context = signing_context(b"");
 
@@ -83,10 +85,12 @@ fn test_ok_for_only_device_key_signatures() {
             .unwrap()
             .into_bytes(),
     );
-    assert!(
-        DeviceKeyProxy::evaluate(request_from_device_key.clone(), Some(config_bytes.clone()))
-            .is_ok()
-    );
+    assert!(DeviceKeyProxy::evaluate(
+        request_from_device_key.clone(),
+        Some(config_bytes.clone()),
+        None
+    )
+    .is_ok());
     // positive for ed25519
     let ed25519_device_key_signature: Ed25519Signature =
         device_keys.ed25519_keys[0].sign(message.as_bytes());
@@ -101,7 +105,7 @@ fn test_ok_for_only_device_key_signatures() {
             .unwrap()
             .into_bytes(),
     );
-    DeviceKeyProxy::evaluate(request_from_device_key, Some(config_bytes.clone())).unwrap();
+    DeviceKeyProxy::evaluate(request_from_device_key, Some(config_bytes.clone()), None).unwrap();
 }
 
 #[test]
@@ -159,9 +163,13 @@ fn test_fail_bad_signatures() {
     let config_bytes = serde_json::to_vec(&json_config).unwrap();
     // fail for edcsa
     assert_eq!(
-        DeviceKeyProxy::evaluate(request_from_device_key.clone(), Some(config_bytes.clone()))
-            .unwrap_err()
-            .to_string(),
+        DeviceKeyProxy::evaluate(
+            request_from_device_key.clone(),
+            Some(config_bytes.clone()),
+            None
+        )
+        .unwrap_err()
+        .to_string(),
         "Error::InvalidSignatureRequest(\"Unable to verify ecdsa signature\")"
     );
     let sr25519_non_device_key_signature: Sr25519Signature =
@@ -179,9 +187,13 @@ fn test_fail_bad_signatures() {
             .into_bytes(),
     );
     assert_eq!(
-        DeviceKeyProxy::evaluate(request_from_device_key.clone(), Some(config_bytes.clone()))
-            .unwrap_err()
-            .to_string(),
+        DeviceKeyProxy::evaluate(
+            request_from_device_key.clone(),
+            Some(config_bytes.clone()),
+            None
+        )
+        .unwrap_err()
+        .to_string(),
         "Error::InvalidSignatureRequest(\"Unable to verify sr25519 signature\")"
     );
     // fail for ed25519
@@ -199,9 +211,13 @@ fn test_fail_bad_signatures() {
             .into_bytes(),
     );
     assert_eq!(
-        DeviceKeyProxy::evaluate(request_from_device_key.clone(), Some(config_bytes.clone()))
-            .unwrap_err()
-            .to_string(),
+        DeviceKeyProxy::evaluate(
+            request_from_device_key.clone(),
+            Some(config_bytes.clone()),
+            None
+        )
+        .unwrap_err()
+        .to_string(),
         "Error::InvalidSignatureRequest(\"Unable to verify ed25519 signature\")"
     );
 }
@@ -258,7 +274,8 @@ fn test_fails_pub_key_not_found() {
     assert_eq!(
         DeviceKeyProxy::evaluate(
             request_from_non_device_key.clone(),
-            Some(config_bytes.clone())
+            Some(config_bytes.clone()),
+            None
         )
         .unwrap_err()
         .to_string(),
@@ -284,7 +301,8 @@ fn test_fails_pub_key_not_found() {
     assert_eq!(
         DeviceKeyProxy::evaluate(
             request_from_non_device_key.clone(),
-            Some(config_bytes.clone())
+            Some(config_bytes.clone()),
+            None
         )
         .unwrap_err()
         .to_string(),
@@ -306,7 +324,7 @@ fn test_fails_pub_key_not_found() {
             .into_bytes(),
     );
     assert_eq!(
-        DeviceKeyProxy::evaluate(request_from_non_device_key, Some(config_bytes))
+        DeviceKeyProxy::evaluate(request_from_non_device_key, Some(config_bytes), None)
             .unwrap_err()
             .to_string(),
         "Error::InvalidSignatureRequest(\"Ed25519 Public key not in config\")"
@@ -347,7 +365,8 @@ fn test_fails_with_no_aux_or_config() {
     assert_eq!(
         DeviceKeyProxy::evaluate(
             request_from_device_key_no_aux.clone(),
-            Some(config_bytes.clone())
+            Some(config_bytes.clone()),
+            None
         )
         .unwrap_err()
         .to_string(),
@@ -378,7 +397,7 @@ fn test_fails_with_no_aux_or_config() {
         ),
     };
     assert_eq!(
-        DeviceKeyProxy::evaluate(request_from_device_key.clone(), None)
+        DeviceKeyProxy::evaluate(request_from_device_key.clone(), None, None)
             .unwrap_err()
             .to_string(),
         "Error::Evaluation(\"No config provided.\")"
@@ -391,7 +410,7 @@ fn test_fails_with_no_aux_or_config() {
             .into_bytes(),
     );
     assert_eq!(
-        DeviceKeyProxy::evaluate(request_from_device_key, Some(config_bytes.clone()))
+        DeviceKeyProxy::evaluate(request_from_device_key, Some(config_bytes.clone()), None)
             .unwrap_err()
             .to_string(),
         "Error::InvalidSignatureRequest(\"Invalid public key type\")"

--- a/examples/infinite-loop/src/lib.rs
+++ b/examples/infinite-loop/src/lib.rs
@@ -12,7 +12,11 @@ pub struct InfiniteLoop;
 impl Program for InfiniteLoop {
     /// This is the only function required by the program runtime. `message` is the preimage of the curve element to be
     /// signed, eg. RLP-serialized Ethereum transaction request, raw x86_64 executable, etc.
-    fn evaluate(_signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), Error> {
+    fn evaluate(
+        _signature_request: SignatureRequest,
+        _config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
+    ) -> Result<(), Error> {
         loop {}
         #[allow(unreachable_code)]
         Ok(())

--- a/examples/private-acl/src/lib.rs
+++ b/examples/private-acl/src/lib.rs
@@ -24,7 +24,11 @@ register_custom_getrandom!(always_fail);
 impl Program for PrivateTransactionAcl {
     /// Allow any address given in the pre-defined list (addresses.txt)
     // #[no_mangle]
-    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), CoreError> {
+    fn evaluate(
+        signature_request: SignatureRequest,
+        _config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
+    ) -> Result<(), CoreError> {
         // parse the raw tx into some type
         let parsed_tx = <Evm as Architecture>::TransactionRequest::try_parse(
             signature_request.message.as_slice(),
@@ -72,7 +76,7 @@ mod tests {
             auxilary_data: None,
         };
 
-        assert!(PrivateTransactionAcl::evaluate(signature_request, None).is_ok());
+        assert!(PrivateTransactionAcl::evaluate(signature_request, None, None).is_ok());
     }
 
     #[test]
@@ -83,6 +87,6 @@ mod tests {
             auxilary_data: None,
         };
 
-        assert!(PrivateTransactionAcl::evaluate(signature_request, None).is_err());
+        assert!(PrivateTransactionAcl::evaluate(signature_request, None, None).is_err());
     }
 }

--- a/examples/risczero-zkvm-verification/src/lib.rs
+++ b/examples/risczero-zkvm-verification/src/lib.rs
@@ -17,7 +17,7 @@ register_custom_getrandom!(always_fail);
 pub struct ZkVmVerificationProgram;
 
 impl Program for ZkVmVerificationProgram {
-    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), Error> {
+    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>, _oracle_data: Option<Vec<u8>>) -> Result<(), Error> {
         let image_id: [u32; 8] = bincode::deserialize(&signature_request.message)
             .map_err(|_| Error::InvalidSignatureRequest("Could not parse image_id".to_string()))?;
 
@@ -92,7 +92,7 @@ mod tests {
             auxilary_data: Some(bincode::serialize(&read_test_receipt()).unwrap()),
         };
 
-        assert!(ZkVmVerificationProgram::evaluate(signature_request, None).is_ok());
+        assert!(ZkVmVerificationProgram::evaluate(signature_request, None, None).is_ok());
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod tests {
             auxilary_data: Some(bincode::serialize(&read_test_receipt()).unwrap()),
         };
 
-        assert!(ZkVmVerificationProgram::evaluate(signature_request, None).is_err());
+        assert!(ZkVmVerificationProgram::evaluate(signature_request, None, None).is_err());
     }
 
     // Test helper functions

--- a/examples/siwe/src/lib.rs
+++ b/examples/siwe/src/lib.rs
@@ -24,7 +24,11 @@ const ALLOWED_DOMAIN: &str = "localhost";
 pub struct Siwe;
 
 impl Program for Siwe {
-    fn evaluate(signature_request: SignatureRequest, _config: Option<Vec<u8>>) -> Result<(), Error> {
+    fn evaluate(
+        signature_request: SignatureRequest,
+        _config: Option<Vec<u8>>,
+        _oracle_data: Option<Vec<u8>>,
+    ) -> Result<(), Error> {
         let string_message = String::from_utf8(signature_request.message)
             .map_err(|err| Error::Evaluation(err.to_string()))?;
         let siwe_message = string_message
@@ -71,7 +75,7 @@ Issued At: 2022-01-28T23:28:16.013Z"
             auxilary_data: None,
         };
 
-        assert!(Siwe::evaluate(signature_request, None).is_ok());
+        assert!(Siwe::evaluate(signature_request, None, None).is_ok());
     }
 
     #[test]
@@ -92,7 +96,7 @@ Issued At: 2022-01-28T23:28:16.013Z"
             auxilary_data: None,
         };
 
-        assert!(Siwe::evaluate(signature_request, None).is_err());
+        assert!(Siwe::evaluate(signature_request, None, None).is_err());
     }
 
     #[test]
@@ -113,6 +117,6 @@ Issued At: 2022-01-28T23:28:16.013Z"
             auxilary_data: None,
         };
 
-        assert!(Siwe::evaluate(signature_request, None).is_err());
+        assert!(Siwe::evaluate(signature_request, None, None).is_err());
     }
 }

--- a/runtime/tests/runtime.rs
+++ b/runtime/tests/runtime.rs
@@ -21,7 +21,7 @@ fn test_barebones_component() {
         auxilary_data: None,
     };
 
-    let res = runtime.evaluate(BAREBONES_COMPONENT_WASM, &signature_request, None);
+    let res = runtime.evaluate(BAREBONES_COMPONENT_WASM, &signature_request, None, None);
     assert!(res.is_ok());
 }
 
@@ -36,7 +36,7 @@ fn test_barebones_component_fails_with_data_length_less_than_10() {
         auxilary_data: None,
     };
 
-    let res = runtime.evaluate(BAREBONES_COMPONENT_WASM, &signature_request, None);
+    let res = runtime.evaluate(BAREBONES_COMPONENT_WASM, &signature_request, None, None);
     assert!(res.is_err());
 }
 
@@ -49,7 +49,7 @@ fn test_empty_bytecode_fails() {
         auxilary_data: None,
     };
 
-    let res = runtime.evaluate(&[], &signature_request, None);
+    let res = runtime.evaluate(&[], &signature_request, None, None);
     assert_eq!(res.unwrap_err().to_string(), "Bytecode length is zero");
 }
 
@@ -62,7 +62,7 @@ fn test_infinite_loop() {
         auxilary_data: None,
     };
 
-    let res = runtime.evaluate(INFINITE_LOOP_WASM, &signature_request, None);
+    let res = runtime.evaluate(INFINITE_LOOP_WASM, &signature_request, None, None);
     assert_eq!(res.unwrap_err().to_string(), "Out of fuel");
 }
 

--- a/templates/basic-template/src/tests.rs
+++ b/templates/basic-template/src/tests.rs
@@ -7,7 +7,7 @@ fn test_should_sign() {
         auxilary_data: None,
     };
 
-    assert!({{project-name | upper_camel_case}}::evaluate(signature_request, None).is_ok());
+    assert!({{project-name | upper_camel_case}}::evaluate(signature_request, None, None).is_ok());
 }
 
 #[test]
@@ -17,5 +17,5 @@ fn test_should_fail() {
         auxilary_data: None,
     };
 
-    assert!({{project-name | upper_camel_case}}::evaluate(signature_request, None).is_err());
+    assert!({{project-name | upper_camel_case}}::evaluate(signature_request, None, None).is_err());
 }

--- a/wit/application.wit
+++ b/wit/application.wit
@@ -8,7 +8,7 @@ world program {
     evaluation(string)
   }
   /// Evaluates the program given the user's signature request and the program's configuration.
-  export evaluate: func(signature-request: signature-request, config: option<list<u8>>) -> result<_, error>
+  export evaluate: func(signature-request: signature-request, config: option<list<u8>>, oracle-data: option<list<u8>>) -> result<_, error>
   
   /// Programs that use custom hash functions can a custom 32-byte curve point to be signed.
   export custom-hash: func(data: list<u8>) -> option<list<u8>>


### PR DESCRIPTION
This allows us to add oracle data. The data is just bytes that can be passed in from the chain, this is 1/2 the required PR, the next would be to have a program (stored in the program struct pass the location of the oracle data on-chain in). To manage how oracle data gets uploaded we will write pallets and TSSs will pull the data down from the chain