### PR TITLE
Update docker image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is for building the example programs in this repo.
-FROM peg997/build-entropy-programs:version0.1 AS base
+FROM entropyxyz/build-entropy-programs:v0.0.1 AS base
 ARG PACKAGE=template-barebones
 
 WORKDIR /usr/src/programs

--- a/templates/basic-template/Cargo.toml
+++ b/templates/basic-template/Cargo.toml
@@ -32,7 +32,7 @@ package = "entropy:{{project-name}}"
 [package.metadata.entropy-program]
 
 # The docker image used to build this program
-docker-image = "peg997/build-entropy-programs:version0.1"
+docker-image = "entropyxyz/build-entropy-programs:v0.0.1"
 
 # Configuration interface description
 # interface-description = ""

--- a/templates/basic-template/Dockerfile
+++ b/templates/basic-template/Dockerfile
@@ -1,6 +1,6 @@
 # To build this program, and put the .wasm binary in the directory 'output':
 # docker build --output=binary-dir .
-FROM peg997/build-entropy-programs:version0.1 AS base
+FROM entropyxyz/build-entropy-programs:v0.0.1 AS base
 
 WORKDIR /usr/src/programs
 COPY . .


### PR DESCRIPTION
The dockerfile for building programs is now in the entropyxyz dockerhub org rather than my personal dockerhub account, so this updates the name in the Dockerfile here.

Worth noting is that i also updated the rust version used by it when re-publishing.  So building with this image will give different hashes than with the old one.