### PR TITLE
Bump minor versions of programs-core and programs-runtime, for publish

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entropy-programs-core"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Entropy Cryptography <engineering@entropy.xyz>"]
 homepage = "https://entropy.xyz/"
 license = "AGPL-3.0-or-later"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entropy-programs-runtime"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Entropy Cryptography <engineering@entropy.xyz>"]
 homepage = "https://entropy.xyz/"
 license = "AGPL-3.0-or-later"
@@ -10,7 +10,7 @@ description = "Webassembly runtime for running Entropy programs"
 
 [dependencies]
 wasmtime = { version = "12.0.1", features = ["component-model"] }
-entropy-programs-core = { version = "0.10.0", path = "../core" }
+entropy-programs-core = { version = "0.11.0", path = "../core" }
 thiserror = "1.0.47"
 
 [dev-dependencies]


### PR DESCRIPTION
I would like to publish programs-core and programs-runtime as i think it will fix https://github.com/entropyxyz/entropy-core/issues/1182

This PR bumps the version numbers for publishing.

The code of programs-core hasn't actually changed, but since the wit file which is used to build it has changed, it also needs bumping.